### PR TITLE
fix: filter .tar.gz from checksum

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -68,4 +68,4 @@
   set_fact:
     phpfpm_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items: "{{ _checksums }}"
-  when: "('linux_' + go_arch) in item"
+  when: "('linux_' + go_arch) in item and not item.endswith('.tar.gz')"


### PR DESCRIPTION
In the latest version of the php-fpm_exporter `v2.2.0`,  the checksum matches 2 entries for `php-fpm_exporter_2.2.0_linux_amd64`and also `php-fpm_exporter_2.2.0_linux_amd64.tar.gz`, causing an error due to `.tar.gz` being the last one. 

This PR filters the `.tar.gz` entry from the checksums fixing the issue. 

Error Log:

```bash
TASK [umanit.php_fpm_exporter : Get checksum for amd64 architecture] *******************************************************************************************************
martes 20 agosto 2024  11:03:37 -0300 (0:00:01.105)       0:00:17.157 *********
skipping: [localhost] => (item=06fb9b0cf8c7b54745bac71f5e50dc30eff54448353d24fb111209e7f4515009  php-fpm_exporter_2.2.0_windows_amd64.exe)
skipping: [localhost] => (item=15cd3c61e7b4105093b78f513350b795e2b303dce762ccfdba712e612d886418  php-fpm_exporter_2.2.0_windows_arm64.tar.gz)
skipping: [localhost] => (item=42cec68addaf34c1303018b1426edb9cc4dea649dfe77d5359cdf832493eb83d  php-fpm_exporter_2.2.0_darwin_amd64.tar.gz)
skipping: [localhost] => (item=6dead4a1937f96aa42b2ce9794ae33b8ab1f33870123b459248f63e0a38f9c18  php-fpm_exporter_2.2.0_windows_arm64.exe)
skipping: [localhost] => (item=723e3563a56be711db73d25ed6af8fc421d583eb4105696c2483cbca5132977e  php-fpm_exporter_2.2.0_windows_amd64.tar.gz)
skipping: [localhost] => (item=75454955ecff4200aefc00dc26032c841ff7c1f24c0cb35813da4538d43879b4  php-fpm_exporter_2.2.0_linux_arm64.tar.gz)
skipping: [localhost] => (item=87cc442f4cbaf7b4301bd3fb14124f381d632fa4d4f5c8965deb031f1c1b1ac8  php-fpm_exporter_2.2.0_darwin_arm64)
skipping: [localhost] => (item=93bdc79d2a306d5567dbe7af6eba89df94e4f08ff1c781c273b293a4b5931858  php-fpm_exporter_2.2.0_darwin_arm64.tar.gz)
ok: [localhost] => (item=9de0d094aec6ad8a2ea536a5eb8e039ccda4882a2b574ac642d07e589fd5a903  php-fpm_exporter_2.2.0_linux_amd64)
ok: [localhost] => (item=b1c207fcd89f9be20104fd90bc76b3c584987ea5a769c99d5759f79af8322449  php-fpm_exporter_2.2.0_linux_amd64.tar.gz)
skipping: [localhost] => (item=b8d197975d45ca0fc6eb83aa62fc553b08918f3dd4c115d86625d37e70a5212b  php-fpm_exporter_2.2.0_darwin_amd64)
skipping: [localhost] => (item=bbd13fafb94f4b24e541366760d4022d6475f83dae1938053c9f99ae1a9d01f3  php-fpm_exporter_2.2.0_linux_arm64)

....

TASK [umanit.php_fpm_exporter : Download phpfpm_exporter binary] ***********************************************************************************************************
martes 20 agosto 2024  11:03:38 -0300 (0:00:00.027)       0:00:17.713 *********
FAILED - RETRYING: [localhost]: Download phpfpm_exporter binary (5 retries left).
FAILED - RETRYING: [localhost]: Download phpfpm_exporter binary (4 retries left).
FAILED - RETRYING: [localhost]: Download phpfpm_exporter binary (3 retries left).
FAILED - RETRYING: [localhost]: Download phpfpm_exporter binary (2 retries left).
FAILED - RETRYING: [localhost]: Download phpfpm_exporter binary (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 5, "changed": true, "checksum_dest": null, "checksum_src": "785dee0183205e921b49688e43905c11dde68559", "dest": "/usr/local/bin/phpfpm_exporter", "elapsed": 0, "msg": "The checksum for /usr/local/bin/phpfpm_exporter did not match b1c207fcd89f9be20104fd90bc76b3c584987ea5a769c99d5759f79af8322449; it was 9de0d094aec6ad8a2ea536a5eb8e039ccda4882a2b574ac642d07e589fd5a903.", "src": "/root/.ansible/tmp/ansible-moduletmp-1724162631.1875606-w72f4bml/tmpci79toog", "url": "https://github.com/hipages/php-fpm_exporter/releases/download/v2.2.0/php-fpm_exporter_2.2.0_linux_amd64"}

```